### PR TITLE
Trying to make the wrapper more robust against changes in `/include` setup

### DIFF
--- a/Sources/include/inotify_wrapper.h
+++ b/Sources/include/inotify_wrapper.h
@@ -1,0 +1,1 @@
+#include <sys/inotify.h>

--- a/Sources/include/module.modulemap
+++ b/Sources/include/module.modulemap
@@ -1,0 +1,4 @@
+module inotify [system] {
+  header "inotify_wrapper.h"
+  export *
+}

--- a/Sources/inotify_wrapper.c
+++ b/Sources/inotify_wrapper.c
@@ -1,0 +1,3 @@
+int inotify_anchor() {
+    return 0;
+}

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,0 @@
-module inotify [system] {
-  header "/usr/include/x86_64-linux-gnu/sys/inotify.h"
-  export *
-}


### PR DESCRIPTION
The idea is to make a C header that includes the correct header, `<sys/inotify.h>`, which cannot be accessed in such a _setup-agnostic_ way from the `modulemap` file.
This is useful for example, if you were using such a different setup from ours that the `inotify` header is in a **completely different directory** from the one that was specified in this package's original `modulemap`. Module maps can _only use absolute paths for system libraries_. This PR fixes that issue, using a C header as a bridge between the system and the module map. 

I based it off of: https://github.com/apple/swift-package-manager/tree/master/Sources/clibc
I tested it using [this](https://github.com/felix91gr/fswatcher-usage) example program that I made and it works with no errors that I can see.

What do you think of these changes? :)
BTW: thanks for making this package, I really needed it and I was new to the Swift C interop functionalities. Thanks a bunch!